### PR TITLE
Support MATE panel menu themes 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.63])
 AC_INIT([nm-applet],
-        [1.3.90],
+        [1.3.91],
         [https://bugzilla.gnome.org/enter_bug.cgi?product=NetworkManager],
         [network-manager-applet])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.63])
 AC_INIT([nm-applet],
-        [1.5.0],
+        [1.3.90],
         [https://bugzilla.gnome.org/enter_bug.cgi?product=NetworkManager],
         [network-manager-applet])
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,30 +1,26 @@
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# gnomepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for network-manager-applet.
+# Copyright © 2006-2016 the network-manager-applet authors.
+# This file is distributed under the same license as the network-manager-applet package.
 # Wadim Dziedzic <wdziedzic@aviary.pl>, 2006-2008.
 # Tomasz Dominikowski <dominikowski@gmail.com>, 2007-2009.
 # Piotr Zaryk <pzaryk@aviary.pl>, 2008.
 # Piotr Drąg <piotrdrag@gmail.com>, 2009-2016.
-# Aviary.pl <gnomepl@aviary.pl>, 2006-2016.
+# Aviary.pl <community-poland@mozilla.org>, 2006-2016.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: network-manager-applet\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-29 00:40+0200\n"
-"PO-Revision-Date: 2016-07-29 00:41+0200\n"
+"POT-Creation-Date: 2016-08-17 18:41+0200\n"
+"PO-Revision-Date: 2016-08-17 18:42+0200\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish <gnomepl@aviary.pl>\n"
+"Language-Team: Polish <community-poland@mozilla.org>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
-"X-Poedit-Language: Polish\n"
-"X-Poedit-Country: Poland\n"
 
 #: ../nm-applet.desktop.in.h:1 ../src/applet.c:3104
 msgid "Network"
@@ -45,21 +41,21 @@ msgstr "Zarządzanie ustawieniami połączeń sieciowych"
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:1
 msgid "Disable connected notifications"
-msgstr "Wyłączenie powiadomień o połączeniu"
+msgstr "Wyłączenie powiadomień o połączeniu"
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:2
 msgid "Set this to true to disable notifications when connecting to a network."
-msgstr "Ustawienie na „true” wyłącza powiadomienia podczas łączenia z siecią."
+msgstr "Ustawienie na „true” wyłącza powiadomienia podczas łączenia z siecią."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:3
 msgid "Disable disconnected notifications"
-msgstr "Wyłączenie powiadomień o rozłączeniu"
+msgstr "Wyłączenie powiadomień o rozłączeniu"
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:4
 msgid ""
 "Set this to true to disable notifications when disconnecting from a network."
 msgstr ""
-"Ustawienie na „true” wyłącza powiadomienia podczas rozłączania z sieci."
+"Ustawienie na „true” wyłącza powiadomienia podczas rozłączania z sieci."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:5
 msgid "Disable VPN notifications"
@@ -71,16 +67,16 @@ msgid ""
 "disconnecting from a VPN."
 msgstr ""
 "Ustawienie na „true” wyłącza powiadomienia podczas łączenia lub rozłączania "
-"z sieci VPN."
+"z sieci VPN."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:7
 msgid "Suppress networks available notifications"
-msgstr "Wyłączenie powiadomień o dostępnych sieciach"
+msgstr "Wyłączenie powiadomień o dostępnych sieciach"
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:8
 msgid ""
 "Set this to true to disable notifications when Wi-Fi networks are available."
-msgstr "Ustawienie na „true” wyłącza powiadomienia o dostępności sieci Wi-Fi."
+msgstr "Ustawienie na „true” wyłącza powiadomienia o dostępności sieci Wi-Fi."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:9
 msgid "Stamp"
@@ -105,12 +101,12 @@ msgstr ""
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:13
 msgid "Show the applet in notification area"
-msgstr "Wyświetlanie apletu w obszarze powiadamiania"
+msgstr "Wyświetlanie apletu w obszarze powiadamiania"
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:14
 msgid "Set to FALSE to disable displaying the applet in the notification area."
 msgstr ""
-"Ustawienie na „false” wyłącza wyświetlanie apletu w obszarze powiadamiania."
+"Ustawienie na „false” wyłącza wyświetlanie apletu w obszarze powiadamiania."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:15
 msgid "Ignore CA certificate"
@@ -121,7 +117,7 @@ msgid ""
 "Set this to true to disable warnings about CA certificates in EAP "
 "authentication."
 msgstr ""
-"Ustawienie na „true” wyłącza ostrzeżenia o certyfikatach CA podczas "
+"Ustawienie na „true” wyłącza ostrzeżenia o certyfikatach CA podczas "
 "uwierzytelniania EAP."
 
 #: ../org.gnome.nm-applet.gschema.xml.in.h:17
@@ -129,7 +125,7 @@ msgid ""
 "Set this to true to disable warnings about CA certificates in phase 2 of EAP "
 "authentication."
 msgstr ""
-"Ustawienie na „true” wyłącza ostrzeżenia o certyfikatach CA podczas drugiego "
+"Ustawienie na „true” wyłącza ostrzeżenia o certyfikatach CA podczas drugiego "
 "etapu uwierzytelniania EAP."
 
 #: ../nm-connection-editor.appdata.xml.in.h:1
@@ -145,15 +141,15 @@ msgid ""
 "NetworkManager is a system service for managing and configuring your network "
 "connections and devices."
 msgstr ""
-"NetworkManager jest usługą systemową do zarządzania i konfigurowania "
-"połączeń i urządzeń sieciowych."
+"NetworkManager jest usługą systemową do zarządzania i konfigurowania "
+"połączeń i urządzeń sieciowych."
 
 #: ../nm-connection-editor.appdata.xml.in.h:4
 msgid ""
 "The nm-connection-editor program works with NetworkManager to create and "
 "edit existing connection profiles for NetworkManager."
 msgstr ""
-"Program nm-connection-editor umożliwia tworzenie i modyfikowanie "
+"Program nm-connection-editor umożliwia tworzenie i modyfikowanie "
 "istniejących profilów połączeń za pomocą usługi NetworkManager."
 
 #: ../nm-connection-editor.appdata.xml.in.h:5
@@ -259,7 +255,7 @@ msgid ""
 "The VPN connection '%s' failed because the connection attempt timed out."
 msgstr ""
 "\n"
-"Połączenie VPN „%s” się nie powiodło z powodu przekroczenia limitu czasu."
+"Połączenie VPN „%s” się nie powiodło z powodu przekroczenia limitu czasu."
 
 #: ../src/applet.c:856
 #, c-format
@@ -288,7 +284,7 @@ msgid ""
 "The VPN connection '%s' failed because there were no valid VPN secrets."
 msgstr ""
 "\n"
-"Połączenie VPN „%s” się nie powiodło z powodu braku prawidłowych sekretów "
+"Połączenie VPN „%s” się nie powiodło z powodu braku prawidłowych sekretów "
 "VPN."
 
 #: ../src/applet.c:865
@@ -298,7 +294,7 @@ msgid ""
 "The VPN connection '%s' failed because of invalid VPN secrets."
 msgstr ""
 "\n"
-"Połączenie VPN „%s” się nie powiodło z powodu nieprawidłowych sekretów VPN."
+"Połączenie VPN „%s” się nie powiodło z powodu nieprawidłowych sekretów VPN."
 
 #: ../src/applet.c:872
 #, c-format
@@ -456,7 +452,7 @@ msgstr "P_owiadomienia"
 #. 'Connection Information' item
 #: ../src/applet.c:1864
 msgid "Connection _Information"
-msgstr "I_nformacje o połączeniu"
+msgstr "I_nformacje o połączeniu"
 
 #. 'Edit Connections...' item
 #: ../src/applet.c:1872
@@ -465,12 +461,12 @@ msgstr "Modyfikuj połączenia…"
 
 #: ../src/applet.c:1886
 msgid "_About"
-msgstr "_O programie"
+msgstr "_O programie"
 
 #: ../src/applet.c:2171
 #, c-format
 msgid "You are now connected to '%s'."
-msgstr "Połączono z „%s”."
+msgstr "Połączono z „%s”."
 
 #: ../src/applet.c:2214
 msgid "Disconnected"
@@ -531,11 +527,11 @@ msgstr "Aplet NetworkManager"
 
 #: ../src/applet-device-broadband.c:159
 msgid "Wrong PUK code; please contact your provider."
-msgstr "Błędny kod PUK. Proszę skontaktować się z dostawcą."
+msgstr "Błędny kod PUK. Proszę skontaktować się z dostawcą."
 
 #: ../src/applet-device-broadband.c:201
 msgid "Wrong PIN code; please contact your provider."
-msgstr "Błędny kod PIN. Proszę skontaktować się z dostawcą."
+msgstr "Błędny kod PIN. Proszę skontaktować się z dostawcą."
 
 #. Start the spinner to show the progress of the unlock
 #: ../src/applet-device-broadband.c:252
@@ -571,7 +567,7 @@ msgstr "Ustanowiono połączenie"
 
 #: ../src/applet-device-broadband.c:816
 msgid "You are now connected to the Mobile Broadband network."
-msgstr "Połączono z siecią komórkową."
+msgstr "Połączono z siecią komórkową."
 
 #: ../src/applet-device-broadband.c:956 ../src/applet-device-broadband.c:962
 msgid "Mobile Broadband network."
@@ -579,15 +575,15 @@ msgstr "Sieć komórkowa."
 
 #: ../src/applet-device-broadband.c:957
 msgid "You are now registered on the home network."
-msgstr "Zarejestrowano w sieci domowej."
+msgstr "Zarejestrowano w sieci domowej."
 
 #: ../src/applet-device-broadband.c:963
 msgid "You are now registered on a roaming network."
-msgstr "Zarejestrowano w sieci roamingowej."
+msgstr "Zarejestrowano w sieci roamingowej."
 
 #: ../src/applet-device-bt.c:88
 msgid "You are now connected to the mobile broadband network."
-msgstr "Połączono z siecią komórkową."
+msgstr "Połączono z siecią komórkową."
 
 #: ../src/applet-device-bt.c:116 ../src/mobile-helpers.c:599
 #, c-format
@@ -633,7 +629,7 @@ msgstr "Sieć ethernetowa"
 
 #: ../src/applet-device-ethernet.c:133
 msgid "You are now connected to the ethernet network."
-msgstr "Połączono z siecią ethernetową."
+msgstr "Połączono z siecią ethernetową."
 
 #: ../src/applet-device-ethernet.c:161
 #, c-format
@@ -667,7 +663,7 @@ msgstr "Uwierzytelnianie DSL"
 
 #: ../src/applet-device-wifi.c:230
 msgid "_Connect to Hidden Wi-Fi Network..."
-msgstr "_Połącz z ukrytą siecią Wi-Fi…"
+msgstr "_Połącz z ukrytą siecią Wi-Fi…"
 
 #: ../src/applet-device-wifi.c:281
 msgid "Create _New Wi-Fi Network..."
@@ -712,12 +708,12 @@ msgstr "Dostępne sieci Wi-Fi"
 
 #: ../src/applet-device-wifi.c:1181
 msgid "Use the network menu to connect to a Wi-Fi network"
-msgstr "Należy użyć menu sieci, aby połączyć z siecią Wi-Fi"
+msgstr "Należy użyć menu sieci, aby połączyć z siecią Wi-Fi"
 
 #: ../src/applet-device-wifi.c:1364
 #, c-format
 msgid "You are now connected to the Wi-Fi network '%s'."
-msgstr "Połączono z siecią Wi-Fi „%s”."
+msgstr "Połączono z siecią Wi-Fi „%s”."
 
 #: ../src/applet-device-wifi.c:1399
 #, c-format
@@ -759,7 +755,7 @@ msgstr "Dodanie nowego połączenia się nie powiodło"
 
 #: ../src/applet-dialogs.c:41
 msgid "Error displaying connection information:"
-msgstr "Błąd podczas wyświetlania informacji o połączeniu:"
+msgstr "Błąd podczas wyświetlania informacji o połączeniu:"
 
 #: ../src/applet-dialogs.c:72 ../src/connection-editor/page-wifi-security.c:332
 #: ../src/libnma/nma-wifi-dialog.c:946 ../src/libnm-gtk/nm-wifi-dialog.c:948
@@ -936,13 +932,13 @@ msgid ""
 msgstr ""
 "Copyright © 2004-2014 Red Hat, Inc.\n"
 "Copyright © 2005-2008 Novell, Inc.\n"
-"oraz wielu innych współtwórców i tłumaczy społeczności"
+"oraz wielu innych współtwórców i tłumaczy społeczności"
 
 #: ../src/applet-dialogs.c:988
 msgid ""
 "Notification area applet for managing your network devices and connections."
 msgstr ""
-"Aplet obszaru powiadamiania do zarządzania urządzeniami i połączeniami "
+"Aplet obszaru powiadamiania do zarządzania urządzeniami i połączeniami "
 "sieciowymi."
 
 #: ../src/applet-dialogs.c:990
@@ -968,7 +964,7 @@ msgstr "Hasło do sieci komórkowej"
 #: ../src/applet-dialogs.c:1040
 #, c-format
 msgid "A password is required to connect to '%s'."
-msgstr "Wymagane hasło do połączenia z „%s”."
+msgstr "Wymagane hasło do połączenia z „%s”."
 
 #: ../src/applet-dialogs.c:1055
 msgid "Password:"
@@ -1051,7 +1047,7 @@ msgid ""
 "IP addresses identify your computer on the network.  Click the \"Add\" "
 "button to add an IP address."
 msgstr ""
-"Adresy IP identyfikują komputery w sieci. Proszę nacisnąć przycisk „Dodaj”, "
+"Adresy IP identyfikują komputery w sieci. Proszę nacisnąć przycisk „Dodaj”, "
 "aby dodać adres IP."
 
 #: ../src/connection-editor/ce-ip4-routes.ui.h:4
@@ -1348,7 +1344,7 @@ msgstr "urządzenie"
 #: ../src/connection-editor/ce-page.c:650
 msgid "Failed to update connection secrets due to an unknown error."
 msgstr ""
-"Zaktualizowanie ustawień połączenia się nie powiodło z powodu nieznanego "
+"Zaktualizowanie ustawień połączenia się nie powiodło z powodu nieznanego "
 "błędu."
 
 #: ../src/connection-editor/ce-page-dcb.ui.h:1
@@ -1525,7 +1521,7 @@ msgid ""
 "Enter the allowed link bandwidth percent each Priority Group may use.  The "
 "sum of all groups must total 100%."
 msgstr ""
-"Proszę podać dozwolone pasmo łącza w procentach, które każda grupa "
+"Proszę podać dozwolone pasmo łącza w procentach, które każda grupa "
 "priorytetowa może używać. Suma wszystkich grup musi wynosić 100%."
 
 #: ../src/connection-editor/ce-page-dcb.ui.h:46
@@ -1706,15 +1702,15 @@ msgstr ""
 
 #: ../src/connection-editor/ce-page-general.ui.h:1
 msgid "Automatically connect to _VPN when using this connection"
-msgstr "Automatyczne łączenie z _VPN podczas używania tego połączenia"
+msgstr "Automatyczne łączenie z _VPN podczas używania tego połączenia"
 
 #: ../src/connection-editor/ce-page-general.ui.h:2
 msgid "All _users may connect to this network"
-msgstr "Wszyscy _użytkownicy mogą łączyć się z tą siecią"
+msgstr "Wszyscy _użytkownicy mogą łączyć się z tą siecią"
 
 #: ../src/connection-editor/ce-page-general.ui.h:3
 msgid "_Automatically connect to this network when it is available"
-msgstr "_Automatyczne łączenie z tą siecią, kiedy jest dostępna"
+msgstr "_Automatyczne łączenie z tą siecią, kiedy jest dostępna"
 
 #: ../src/connection-editor/ce-page-general.ui.h:4
 msgid "Firewall _zone:"
@@ -1737,7 +1733,7 @@ msgstr "Połączony"
 #: ../src/connection-editor/ce-page-ip4.ui.h:2
 #: ../src/connection-editor/ce-page-ip6.ui.h:2
 msgid "Automatic with manual DNS settings"
-msgstr "Automatycznie z ręcznymi ustawieniami DNS"
+msgstr "Automatycznie z ręcznymi ustawieniami DNS"
 
 #: ../src/connection-editor/ce-page-ip4.ui.h:3
 #: ../src/connection-editor/ce-page-ip6.ui.h:3
@@ -1756,7 +1752,7 @@ msgstr "Link-Local"
 #: ../src/connection-editor/page-ip4.c:186
 #: ../src/connection-editor/page-ip6.c:204
 msgid "Shared to other computers"
-msgstr "Współdzielone z innymi komputerami"
+msgstr "Współdzielone z innymi komputerami"
 
 #: ../src/connection-editor/ce-page-ip4.ui.h:6
 #: ../src/connection-editor/ce-page-ip6.ui.h:9
@@ -1775,7 +1771,7 @@ msgid ""
 "enter it here."
 msgstr ""
 "Identyfikator klienta DHCP umożliwia administratorowi sieci dostosować "
-"konfigurację komputerów. Aby użyć identyfikatora, należy go podać w tym "
+"konfigurację komputerów. Aby użyć identyfikatora, należy go podać w tym "
 "miejscu."
 
 #: ../src/connection-editor/ce-page-ip4.ui.h:12
@@ -1822,8 +1818,8 @@ msgid ""
 "When connecting to IPv6-capable networks, allows the connection to complete "
 "if IPv4 configuration fails but IPv6 configuration succeeds."
 msgstr ""
-"Podczas łączenia się z sieciami IPv6 umożliwia ukończenie nawiązania "
-"połączenia, jeśli konfiguracja IPv4 się nie powiedzie, a IPv6 tak."
+"Podczas łączenia się z sieciami IPv6 umożliwia ukończenie nawiązania "
+"połączenia, jeśli konfiguracja IPv4 się nie powiedzie, a IPv6 tak."
 
 #: ../src/connection-editor/ce-page-ip4.ui.h:19
 #: ../src/connection-editor/ce-page-ip6.ui.h:21
@@ -1866,8 +1862,8 @@ msgid ""
 "When connecting to IPv4-capable networks, allows the connection to complete "
 "if IPv6 configuration fails but IPv4 configuration succeeds."
 msgstr ""
-"Podczas łączenia się z sieciami IPv4 umożliwia ukończenie nawiązania "
-"połączenia, jeśli konfiguracja IPv6 się nie powiedzie, a IPv4 tak."
+"Podczas łączenia się z sieciami IPv4 umożliwia ukończenie nawiązania "
+"połączenia, jeśli konfiguracja IPv6 się nie powiedzie, a IPv4 tak."
 
 #: ../src/connection-editor/ce-page-mobile.ui.h:1
 #: ../src/connection-editor/ce-page-team.ui.h:26
@@ -1993,7 +1989,7 @@ msgid ""
 "Number of bursts of unsolicited NAs and gratuitous ARP packets sent after "
 "port is enabled or disabled."
 msgstr ""
-"Liczba wybuchów niezamawianych NA i nieuzasadnionych pakietów ARP wysłanych "
+"Liczba wybuchów niezamawianych NA i nieuzasadnionych pakietów ARP wysłanych "
 "po włączeniu lub wyłączeniu portu."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:9
@@ -2023,7 +2019,7 @@ msgid ""
 "Value is positive number in milliseconds. Specifies an interval between "
 "bursts of notify-peer packets."
 msgstr ""
-"Wartość to dodatnia liczba w milisekundach. Określa odstęp między wybuchami "
+"Wartość to dodatnia liczba w milisekundach. Określa odstęp między wybuchami "
 "pakietów „notify-peer”."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:14
@@ -2065,7 +2061,7 @@ msgid ""
 "Value is positive number in milliseconds. Specifies an interval between "
 "bursts of multicast group rejoin requests."
 msgstr ""
-"Wartość to dodatnia liczba w milisekundach. Określa odstęp między wybuchami "
+"Wartość to dodatnia liczba w milisekundach. Określa odstęp między wybuchami "
 "żądań ponownego dołączenia do grupy multikastowej."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:21
@@ -2135,8 +2131,8 @@ msgid ""
 "Hostname to be converted to IP address which will be filled into ARP request "
 "as source address."
 msgstr ""
-"Nazwa komputera konwertowana do adresu IP, który zostanie umieszczony w "
-"żądaniu ARP jako adres źródłowy."
+"Nazwa komputera konwertowana do adresu IP, który zostanie umieszczony "
+"w żądaniu ARP jako adres źródłowy."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:34
 #: ../src/connection-editor/ce-page-team.ui.h:80
@@ -2144,18 +2140,18 @@ msgid ""
 "Hostname to be converted to IP address which will be filled into request as "
 "destination address."
 msgstr ""
-"Nazwa komputera konwertowana do adresu IP, który zostanie umieszczony w "
-"żądaniu ARP jako adres docelowy."
+"Nazwa komputera konwertowana do adresu IP, który zostanie umieszczony "
+"w żądaniu ARP jako adres docelowy."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:35
 #: ../src/connection-editor/ce-page-team.ui.h:81
 msgid "Ignore invalid packets from _active ports"
-msgstr "Ignorowanie nieprawidłowych pakietów z _aktywnych portów"
+msgstr "Ignorowanie nieprawidłowych pakietów z _aktywnych portów"
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:36
 #: ../src/connection-editor/ce-page-team.ui.h:83
 msgid "Ignore invalid packets from i_nactive ports"
-msgstr "Ignorowanie nieprawidłowych pakietów z _nieaktywnych portów"
+msgstr "Ignorowanie nieprawidłowych pakietów z _nieaktywnych portów"
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:37
 #: ../src/connection-editor/ce-page-team.ui.h:84
@@ -2185,13 +2181,13 @@ msgstr ""
 #: ../src/connection-editor/ce-page-team.ui.h:87
 msgid ""
 "The delay between the link coming up and the runner being notified about it."
-msgstr "Opóźnienie między włączeniem łącza a powiadomieniem wykonywania."
+msgstr "Opóźnienie między włączeniem łącza a powiadomieniem wykonywania."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:41
 #: ../src/connection-editor/ce-page-team.ui.h:88
 msgid ""
 "The delay between the link going down and the runner being notified about it."
-msgstr "Opóźnienie między wyłączeniem łącza a powiadomieniem wykonywania."
+msgstr "Opóźnienie między wyłączeniem łącza a powiadomieniem wykonywania."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:42
 #: ../src/connection-editor/ce-page-team.ui.h:89
@@ -2203,7 +2199,7 @@ msgstr "Odstęp między wysyłanymi żądaniami."
 msgid ""
 "The delay between link watch initialization and the first request being sent."
 msgstr ""
-"Opóźnienie między inicjacją obserwowania łącza a wysłaniem pierwszego "
+"Opóźnienie między inicjacją obserwowania łącza a wysłaniem pierwszego "
 "żądania."
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:44
@@ -2219,7 +2215,7 @@ msgstr "Obserwowanie łącza"
 #: ../src/connection-editor/ce-page-team-port.ui.h:46
 #: ../src/connection-editor/ce-page-team.ui.h:93
 msgid "Im_port team configuration from a file..."
-msgstr "Zaimp_ortuj konfigurację zespołową z pliku…"
+msgstr "Zaimp_ortuj konfigurację zespołową z pliku…"
 
 #: ../src/connection-editor/ce-page-team-port.ui.h:47
 #: ../src/connection-editor/ce-page-team.ui.h:94
@@ -2253,15 +2249,15 @@ msgstr "Priorytet portu"
 
 #: ../src/connection-editor/ce-page-team.ui.h:6
 msgid "From the team device"
-msgstr "Z urządzenia zespołowego"
+msgstr "Z urządzenia zespołowego"
 
 #: ../src/connection-editor/ce-page-team.ui.h:7
 msgid "From the active port"
-msgstr "Z aktywnego portu"
+msgstr "Z aktywnego portu"
 
 #: ../src/connection-editor/ce-page-team.ui.h:8
 msgid "From active to team device"
-msgstr "Z aktywnego do urządzenia zespołowego"
+msgstr "Z aktywnego do urządzenia zespołowego"
 
 #: ../src/connection-editor/ce-page-team.ui.h:12
 msgid "_Teamed connections:"
@@ -2362,8 +2358,8 @@ msgid ""
 "This  defines the policy of how hardware addresses of team device and port "
 "devices should be set during the team lifetime."
 msgstr ""
-"To określa politykę ustawiania adresów sprzętowych urządzenia zespołowego i "
-"urządzeń portów podczas cyklu zespołowego."
+"To określa politykę ustawiania adresów sprzętowych urządzenia zespołowego "
+"i urządzeń portów podczas cyklu zespołowego."
 
 #: ../src/connection-editor/ce-page-team.ui.h:53
 msgid "Send LACPDU frames _periodically"
@@ -2387,9 +2383,9 @@ msgid ""
 "LACPDU packets. If checked, packets will be sent once  per second. Otherwise "
 "they will be sent every 30 seconds."
 msgstr ""
-"Opcja określająca częstotliwość pytania partnera łącza o wysłanie pakietów "
-"LACPDU. Jeśli jest zaznaczona, to pakiety będą wysyłane co sekundę. W "
-"przeciwnym przypadku będą wysyłane co 30 sekund."
+"Opcja określająca częstotliwość pytania partnera łącza o wysłanie pakietów "
+"LACPDU. Jeśli jest zaznaczona, to pakiety będą wysyłane co sekundę. "
+"W przeciwnym przypadku będą wysyłane co 30 sekund."
 
 #: ../src/connection-editor/ce-page-team.ui.h:57
 msgid "_System priority:"
@@ -2413,7 +2409,7 @@ msgid ""
 "carrier in the master interface, value can be 1 – 255."
 msgstr ""
 "Określa minimalną liczbę portów, które muszą być aktywne przed zapewnieniem "
-"operatora w głównym interfejsie, wartość może wynosić 1-255."
+"operatora w głównym interfejsie, wartość może wynosić 1-255."
 
 #: ../src/connection-editor/ce-page-team.ui.h:62
 msgid "This selects the policy of how the aggregators will be selected."
@@ -2433,7 +2429,7 @@ msgstr "_Pola sumy kontrolnej przesyłania"
 
 #: ../src/connection-editor/ce-page-team.ui.h:65
 msgid "In tenths of a second. Periodic interval between rebalancing."
-msgstr "W dziesiątkach sekund. Okresowy odstęp między ponownym równoważeniem."
+msgstr "W dziesiątkach sekund. Okresowy odstęp między ponownym równoważeniem."
 
 #: ../src/connection-editor/ce-page-team.ui.h:66
 msgid "Name of active Tx balancer. Active Tx balancing is disabled by default."
@@ -2509,7 +2505,7 @@ msgstr "A (5 GHz)"
 
 #: ../src/connection-editor/ce-page-wifi.ui.h:3
 msgid "B/G (2.4 GHz)"
-msgstr "B/G (2.4 GHz)"
+msgstr "B/G (2,4 GHz)"
 
 #: ../src/connection-editor/ce-page-wifi.ui.h:4
 msgid "Client"
@@ -2608,7 +2604,7 @@ msgid ""
 "In most cases, the provider's PPP servers will support all authentication "
 "methods.  If connections fail, try disabling support for some methods."
 msgstr ""
-"W większości przypadków serwery dostawcy usług PPP obsługują wszystkie "
+"W większości przypadków serwery dostawcy usług PPP obsługują wszystkie "
 "metody uwierzytelniania. Jeśli połączenie zawodzi, proszę spróbować wyłączyć "
 "obsługę niektórych metod."
 
@@ -2676,7 +2672,7 @@ msgid ""
 "The connection editor dialog could not be initialized due to an unknown "
 "error."
 msgstr ""
-"Nie można zainicjować okna dialogowego edytora połączeń z powodu nieznanego "
+"Nie można zainicjować okna dialogowego edytora połączeń z powodu nieznanego "
 "błędu."
 
 #: ../src/connection-editor/connection-helpers.c:410
@@ -2898,7 +2894,7 @@ msgstr "Błąd podczas modyfikowania połączenia"
 #: ../src/connection-editor/nm-connection-list.c:942
 #, c-format
 msgid "Did not find a connection with UUID '%s'"
-msgstr "Nie odnaleziono połączenia z UUID „%s”"
+msgstr "Nie odnaleziono połączenia z UUID „%s”"
 
 #: ../src/connection-editor/page-8021x-security.c:109
 msgid "802.1X Security"
@@ -3002,7 +2998,7 @@ msgid ""
 "its interface name or permanent MAC or both. Examples: \"em1\", "
 "\"3C:97:0E:42:1A:19\", \"em1 (3C:97:0E:42:1A:19)\""
 msgstr ""
-"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
+"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
 "nazwę interfejsu i/lub trwały adres MAC. Przykłady: „em1”, "
 "„3C:97:0E:42:1A:19”, „em1 (3C:97:0E:42:1A:19)”"
 
@@ -3043,7 +3039,7 @@ msgid ""
 "firewall. Only usable if firewalld is active."
 msgstr ""
 "Strefa określa poziom zaufania połączenia. Domyślna jest nietypowa strefa, "
-"wybranie jej powoduje użycie domyślnej strefy ustawionej w zaporze "
+"wybranie jej powoduje użycie domyślnej strefy ustawionej w zaporze "
 "sieciowej. Można tego używać tylko, jeśli usługa firewalld jest aktywna."
 
 #: ../src/connection-editor/page-general.c:53
@@ -3061,7 +3057,7 @@ msgid ""
 "\"80:00:00:48:fe:80:00:00:00:00:00:00:00:02:c9:03:00:00:0f:65\", \"ib0 "
 "(80:00:00:48:fe:80:00:00:00:00:00:00:00:02:c9:03:00:00:0f:65)\""
 msgstr ""
-"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
+"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
 "nazwę interfejsu i/lub trwały adres MAC. Przykłady: „ib0”, „80:00:00:48:"
 "fe:80:00:00:00:00:00:00:00:02:c9:03:00:00:0f:65”, „ib0 (80:00:00:48:"
 "fe:80:00:00:00:00:00:00:00:02:c9:03:00:00:0f:65)”"
@@ -3209,7 +3205,7 @@ msgstr "Podwójne podrzędne"
 #: ../src/connection-editor/page-master.c:249
 #, c-format
 msgid "Slaves '%s' and '%s' both apply to device '%s'"
-msgstr "Podrzędne „%s” i „%s” stosują się do urządzenia „%s”"
+msgstr "Podrzędne „%s” i „%s” stosują się do urządzenia „%s”"
 
 #: ../src/connection-editor/page-master.c:260
 #, c-format
@@ -3217,8 +3213,8 @@ msgid ""
 "Slaves '%s' and '%s' apply to different virtual ports ('%s' and '%s') of the "
 "same physical device."
 msgstr ""
-"Podrzędne „%s” i „%s” stosują się do różnych wirtualnych portów („%s” i "
-"„%s”) tego samego fizycznego urządzenia."
+"Podrzędne „%s” i „%s” stosują się do różnych wirtualnych portów („%s” "
+"i „%s”) tego samego fizycznego urządzenia."
 
 #: ../src/connection-editor/page-master.c:385
 #, c-format
@@ -3243,8 +3239,8 @@ msgid ""
 "Select the technology your mobile broadband provider uses.  If you are "
 "unsure, ask your provider."
 msgstr ""
-"Proszę wybrać technologię używaną przez dostawcę połączenia komórkowego. W "
-"razie wątpliwości należy zapytać dostawcę."
+"Proszę wybrać technologię używaną przez dostawcę połączenia komórkowego. "
+"W razie wątpliwości należy zapytać dostawcę."
 
 #: ../src/connection-editor/page-mobile.c:562
 msgid "My provider uses _GSM-based technology (i.e. GPRS, EDGE, UMTS, HSDPA)"
@@ -3411,7 +3407,7 @@ msgid ""
 "not have the correct VPN plugin installed."
 msgstr ""
 "Należy wybrać typ VPN, który zamierza się nawiązać. Jeśli wymagany typ "
-"połączenia VPN nie jest dostępny w liście, odpowiednia wtyczka VPN może nie "
+"połączenia VPN nie jest dostępny w liście, odpowiednia wtyczka VPN może nie "
 "być zainstalowana."
 
 #: ../src/connection-editor/page-wifi.c:77
@@ -3428,7 +3424,7 @@ msgid ""
 "its interface name or permanent MAC or both. Examples: \"wlan0\", "
 "\"3C:97:0E:42:1A:19\", \"wlan0 (3C:97:0E:42:1A:19)\""
 msgstr ""
-"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
+"Ta opcja blokuje to połączenie z urządzeniem sieciowym określonym przez jego "
 "nazwę interfejsu i/lub trwały adres MAC. Przykłady: „wlan0”, "
 "„3C:97:0E:42:1A:19”, „wlan0 (3C:97:0E:42:1A:19)”"
 
@@ -3471,18 +3467,18 @@ msgstr "Dynamiczny WEP (802.1X)"
 #: ../src/connection-editor/page-wifi-security.c:358
 #: ../src/libnma/nma-wifi-dialog.c:973 ../src/libnm-gtk/nm-wifi-dialog.c:975
 msgid "WPA & WPA2 Personal"
-msgstr "WPA i WPA2 Personal"
+msgstr "WPA i WPA2 Personal"
 
 #: ../src/connection-editor/page-wifi-security.c:371
 #: ../src/libnma/nma-wifi-dialog.c:987 ../src/libnm-gtk/nm-wifi-dialog.c:989
 msgid "WPA & WPA2 Enterprise"
-msgstr "WPA i WPA2 Enterprise"
+msgstr "WPA i WPA2 Enterprise"
 
 #: ../src/connection-editor/page-wifi-security.c:413
 msgid "Could not load Wi-Fi security user interface; missing Wi-Fi setting."
 msgstr "Nie można wczytać interfejsu użytkownika Wi-Fi. Brak ustawienia Wi-Fi."
 
-# tłumaczenie całości jest okropnie długie, a to nazwa karty tylko i wyłącznie przy tworzeniu połączenia z nową siecią *bezprzewodową*, więc nie ma sensu przedłużać
+# tłumaczenie całości jest okropnie długie, a to nazwa karty tylko i wyłącznie przy tworzeniu połączenia z nową siecią *bezprzewodową*, więc nie ma sensu przedłużać
 #: ../src/connection-editor/page-wifi-security.c:424
 msgid "Wi-Fi Security"
 msgstr "Zabezpieczenia"
@@ -3499,7 +3495,7 @@ msgstr "brak SSID"
 #: ../src/connection-editor/page-wifi-security.c:512
 #, c-format
 msgid "Security not compatible with Ad-Hoc mode"
-msgstr "Zabezpieczenie jest niezgodne z trybem ad-hoc"
+msgstr "Zabezpieczenie jest niezgodne z trybem ad-hoc"
 
 #: ../src/connection-editor/vpn-helpers.c:141
 msgid "Cannot import VPN connection"
@@ -3514,7 +3510,7 @@ msgid ""
 "Error: %s."
 msgstr ""
 "Plik „%s” nie może zostać odczytany lub nie zawiera rozpoznawanych "
-"informacji o połączeniu VPN\n"
+"informacji o połączeniu VPN\n"
 "\n"
 "Błąd: %s."
 
@@ -3525,7 +3521,7 @@ msgstr "nieznany błąd"
 #: ../src/connection-editor/vpn-helpers.c:218
 #, c-format
 msgid "A file named \"%s\" already exists."
-msgstr "Plik o nazwie „%s” już istnieje."
+msgstr "Plik o nazwie „%s” już istnieje."
 
 #: ../src/connection-editor/vpn-helpers.c:220
 msgid "_Replace"
@@ -3565,7 +3561,7 @@ msgstr "Automatyczne odblokowywanie tego urządzenia"
 
 #: ../src/info.ui.h:1
 msgid "Connection Information"
-msgstr "Informacje o połączeniu"
+msgstr "Informacje o połączeniu"
 
 #: ../src/info.ui.h:3
 msgid "Active Network Connections"
@@ -3608,7 +3604,7 @@ msgstr ""
 "Zostanie utworzone połączenie do dostawcy Internetu używając wybranych "
 "ustawień. Jeśli połączenie nie powiedzie się lub nie będzie można uzyskać "
 "dostępu do zasobów sieciowych, należy powtórnie sprawdzić ustawienia. Aby je "
-"zmodyfikować, należy wybrać „Połączenia sieciowe” z menu System >> "
+"zmodyfikować, należy wybrać „Połączenia sieciowe” z menu System → "
 "Preferencje."
 
 #: ../src/libnma/nma-mobile-wizard.c:261
@@ -3642,7 +3638,7 @@ msgstr ""
 "Ostrzeżenie: wybranie niepoprawnego planu może spowodować problemy taryfowe "
 "dla konta komórkowego lub zakłócić łączność.\n"
 "\n"
-"W razie wątpliwości dotyczących planu należy zapytać dostawcę o APN planu."
+"W razie wątpliwości dotyczących planu należy zapytać dostawcę o APN planu."
 
 #: ../src/libnma/nma-mobile-wizard.c:508
 #: ../src/libnm-gtk/nm-mobile-wizard.c:509
@@ -3657,7 +3653,7 @@ msgstr "Planu nie ma na liście…"
 #: ../src/libnma/nma-mobile-wizard.c:710
 #: ../src/libnm-gtk/nm-mobile-wizard.c:711
 msgid "Select your provider from a _list:"
-msgstr "P_roszę wybrać dostawcę z listy:"
+msgstr "P_roszę wybrać dostawcę z listy:"
 
 #: ../src/libnma/nma-mobile-wizard.c:723
 #: ../src/libnm-gtk/nm-mobile-wizard.c:724
@@ -3725,7 +3721,7 @@ msgid ""
 "This assistant helps you easily set up a mobile broadband connection to a "
 "cellular (3G) network."
 msgstr ""
-"Ten asystent pomaga w łatwym ustawieniu połączenia komórkowego z siecią 3G."
+"Ten asystent pomaga w łatwym ustawieniu połączenia komórkowego z siecią 3G."
 
 #: ../src/libnma/nma-mobile-wizard.c:1360
 #: ../src/libnm-gtk/nm-mobile-wizard.c:1361
@@ -3778,7 +3774,7 @@ msgstr "Przechowywanie hasła dla wszystkich użytkowników"
 
 #: ../src/libnma/nma-ui-utils.c:51 ../src/libnm-gtk/nm-ui-utils.c:617
 msgid "Ask for this password every time"
-msgstr "Pytanie o hasło za każdym razem"
+msgstr "Pytanie o hasło za każdym razem"
 
 #: ../src/libnma/nma-ui-utils.c:52 ../src/libnm-gtk/nm-ui-utils.c:618
 msgid "The password is not required"
@@ -3808,7 +3804,7 @@ msgid ""
 "Either a password is missing or the connection is invalid. In the latter "
 "case, you have to edit the connection with nm-connection-editor first"
 msgstr ""
-"Brak hasła lub połączenie jest nieprawidłowe. W tym drugim przypadku należy "
+"Brak hasła lub połączenie jest nieprawidłowe. W tym drugim przypadku należy "
 "najpierw zmodyfikować połączenie za pomocą programu nm-connection-editor"
 
 #: ../src/libnma/nma-wifi-dialog.c:465 ../src/libnm-gtk/nm-wifi-dialog.c:465
@@ -3833,15 +3829,15 @@ msgstr "_Utwórz"
 msgid ""
 "Passwords or encryption keys are required to access the Wi-Fi network '%s'."
 msgstr ""
-"Do połączenia z siecią Wi-Fi „%s” wymagane są hasła lub klucze szyfrujące."
+"Do połączenia z siecią Wi-Fi „%s” wymagane są hasła lub klucze szyfrujące."
 
 #: ../src/libnma/nma-wifi-dialog.c:1159 ../src/libnm-gtk/nm-wifi-dialog.c:1163
 msgid "Wi-Fi Network Authentication Required"
-msgstr "Wymagane uwierzytelnienie w sieci Wi-Fi"
+msgstr "Wymagane uwierzytelnienie w sieci Wi-Fi"
 
 #: ../src/libnma/nma-wifi-dialog.c:1161 ../src/libnm-gtk/nm-wifi-dialog.c:1165
 msgid "Authentication required by Wi-Fi network"
-msgstr "Wymagane uwierzytelnienie w sieci Wi-Fi"
+msgstr "Wymagane uwierzytelnienie w sieci Wi-Fi"
 
 #: ../src/libnma/nma-wifi-dialog.c:1166 ../src/libnm-gtk/nm-wifi-dialog.c:1170
 msgid "Create New Wi-Fi Network"
@@ -3857,7 +3853,7 @@ msgstr "Proszę wprowadzić nazwę sieci Wi-Fi, jaka ma zostać utworzona."
 
 #: ../src/libnma/nma-wifi-dialog.c:1171 ../src/libnm-gtk/nm-wifi-dialog.c:1175
 msgid "Connect to Hidden Wi-Fi Network"
-msgstr "Połączenie z ukrytą siecią Wi-Fi"
+msgstr "Połączenie z ukrytą siecią Wi-Fi"
 
 #: ../src/libnma/nma-wifi-dialog.c:1173 ../src/libnm-gtk/nm-wifi-dialog.c:1177
 msgid "Hidden Wi-Fi network"
@@ -3868,7 +3864,7 @@ msgid ""
 "Enter the name and security details of the hidden Wi-Fi network you wish to "
 "connect to."
 msgstr ""
-"Proszę wprowadzić nazwę i ustawienia zabezpieczeń dla żądanej sieci Wi-Fi."
+"Proszę wprowadzić nazwę i ustawienia zabezpieczeń dla żądanej sieci Wi-Fi."
 
 #: ../src/libnma/wifi.ui.h:2 ../src/libnm-gtk/wifi.ui.h:2
 msgid "Wi-Fi _security:"
@@ -3931,8 +3927,8 @@ msgid ""
 "It is not intended for command-line interaction but instead runs in the "
 "GNOME desktop environment."
 msgstr ""
-"Nie jest przeznaczony do uruchamiania w wierszu poleceń. Powinien być "
-"uruchamiany w środowisku GNOME."
+"Nie jest przeznaczony do uruchamiania w wierszu poleceń. Powinien być "
+"uruchamiany w środowisku GNOME."
 
 #: ../src/mb-menu-item.c:52
 msgid "EVDO"
@@ -4019,7 +4015,7 @@ msgstr "Sieć roamingowa"
 #: ../src/mobile-helpers.c:331
 #, c-format
 msgid "PIN code for SIM card '%s' on '%s'"
-msgstr "Kod PIN dla karty SIM „%s” w „%s”"
+msgstr "Kod PIN dla karty SIM „%s” w „%s”"
 
 #: ../src/mobile-helpers.c:464
 msgid "PIN code required"
@@ -4046,7 +4042,7 @@ msgstr "Połączenie %s"
 
 #: ../src/wireless-security/eap-method.c:57
 msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nieokreślony błąd w zabezpieczeniach 802.1X (WPA-EAP)"
+msgstr "nieokreślony błąd w zabezpieczeniach 802.1X (WPA-EAP)"
 
 #: ../src/wireless-security/eap-method.c:233
 msgid "no file selected"
@@ -4304,7 +4300,7 @@ msgstr "brak „wep-key”"
 #, c-format
 msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
 msgstr ""
-"nieprawidłowe „wep-key”: klucz o długości %zu może zawierać tylko liczby "
+"nieprawidłowe „wep-key”: klucz o długości %zu może zawierać tylko liczby "
 "szesnastkowe"
 
 #: ../src/wireless-security/ws-wep-key.c:124
@@ -4312,7 +4308,7 @@ msgstr ""
 msgid ""
 "invalid wep-key: key with a length of %zu must contain only ascii characters"
 msgstr ""
-"nieprawidłowe „wep-key”: klucz o długości %zu może zawierać tylko znaki ASCII"
+"nieprawidłowe „wep-key”: klucz o długości %zu może zawierać tylko znaki ASCII"
 
 #: ../src/wireless-security/ws-wep-key.c:130
 #, c-format
@@ -4368,7 +4364,7 @@ msgstr ""
 #: ../src/wireless-security/ws-wpa-psk.c:79
 msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
 msgstr ""
-"nieprawidłowe „wpa-psk”: nie można zinterpretować klucza o 64 bajtach jako "
+"nieprawidłowe „wpa-psk”: nie można zinterpretować klucza o 64 bajtach jako "
 "szesnastkowy"
 
 #: ../src/wireless-security/ws-wpa-psk.ui.h:2

--- a/src/applet.c
+++ b/src/applet.c
@@ -1597,10 +1597,12 @@ has_usable_wifi (NMApplet *applet)
  */
 static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 {
+    GtkWidget *toplevel;
+
 	g_return_if_fail (menu != NULL);
 	g_return_if_fail (applet != NULL);
 	/*Set up theme and transparency support*/
-	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	toplevel = gtk_widget_get_toplevel (menu);
 	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
 	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
 	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
@@ -1815,6 +1817,10 @@ static GtkWidget *nma_context_menu_create (NMApplet *applet)
 	GtkMenuShell *menu;
 	guint id;
 	static gboolean icons_shown = FALSE;
+    GtkWidget *toplevel;
+    GtkStyleContext *context;
+    GdkScreen *screen;
+    GdkVisual *visual;
 
 	g_return_val_if_fail (applet != NULL, NULL);
 
@@ -1900,13 +1906,12 @@ static GtkWidget *nma_context_menu_create (NMApplet *applet)
 	}
 
 	/*Set up theme and transparency support*/
-	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	toplevel = gtk_widget_get_toplevel (menu);
 	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
-	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
-	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	visual = gdk_screen_get_rgba_visual(screen);
 	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
 	/* Set menu and it's toplevel window to follow panel theme */
-	GtkStyleContext *context;
 	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
 	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 	gtk_style_context_add_class(context,"mate-panel-menu-bar");

--- a/src/applet.c
+++ b/src/applet.c
@@ -1096,7 +1096,7 @@ applet_get_active_vpn_connection (NMApplet *applet,
 {
 	const GPtrArray *active_list;
 	NMActiveConnection *ret = NULL;
-	NMVpnConnectionState state = NM_VPN_CONNECTION_STATE_UNKNOWN;
+	NMVpnConnectionState state;
 	int i;
 
 	active_list = nm_client_get_active_connections (applet->nm_client);
@@ -1599,6 +1599,17 @@ static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 {
 	g_return_if_fail (menu != NULL);
 	g_return_if_fail (applet != NULL);
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+		gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 
 	if (applet->status_icon)
 		gtk_status_icon_set_tooltip_text (applet->status_icon, NULL);
@@ -1888,6 +1899,17 @@ static GtkWidget *nma_context_menu_create (NMApplet *applet)
 		gtk_menu_shell_append (menu, menu_item);
 	}
 
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 	gtk_widget_show_all (GTK_WIDGET (menu));
 
 	return GTK_WIDGET (menu);
@@ -3330,4 +3352,3 @@ static void nma_class_init (NMAppletClass *klass)
 
 	oclass->finalize = finalize;
 }
-


### PR DESCRIPTION
In MATE the .mate-panel-mene-bar and .gnome-panel-menu-bar style classes are used to permit theming menus popped up from the panel differently than application menus as specified in the GTK theme. This is used in my UbuntuStudio_Legacy GTK theme and can be used by any theme.
